### PR TITLE
Consolidated rowsum and rowmult, fixed comment typos

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Juqst"
 uuid = "daa2265e-435c-11e9-3d9f-ff710a317597"
 authors = ["Robin Harper <robin.harper@sydney.edu.au>"]
-version = "0.1.1-h"
+version = "0.1.1-i"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/Initial.jl
+++ b/src/Initial.jl
@@ -69,9 +69,9 @@ See also: [`cnot`](@ref), [`hadamard`](@ref), [`phase`](@ref), [`measure`](@ref)
 Related: [`cliffordToTableau`](@ref)
 """
 function Tableau(x::Integer)
-	t  = Tableau(setup(x),x,false,["initialise($x)"],[],true)
-	t.executeCommands = [Expr(:call,:initialise,:_t)]
-	return t
+    t  = Tableau(setup(x),x,false,["initialise($x)"],[],true)
+    t.executeCommands = [Expr(:call,:initialise,:_t)]
+    return t
 end
 
 
@@ -146,15 +146,15 @@ Resets all commands associated with the Tableau.
 See also: [`initialise`](@ref)
 """
 function reinitialise(t::Tableau)
-	initialise(t)
-	t.trackCommands = true
-	t.commands = ["initialise($(t.qubits))"]
-	t.executeCommands = [Expr(:call,:initialise,:_t)]
-	return t
+    initialise(t)
+    t.trackCommands = true
+    t.commands = ["initialise($(t.qubits))"]
+    t.executeCommands = [Expr(:call,:initialise,:_t)]
+    return t
 end
 
 function initialize(t::Tableau)
-	initialise(t)
+    initialise(t)
 end
 
 
@@ -167,8 +167,8 @@ However, unlike reinitialse it does not change the commands associated with the 
 See also: [`reinitialise`](@ref)
 """
 function initialise(t::Tableau)
-	t.state = setup(t.qubits)
-	return t
+    t.state = setup(t.qubits)
+    return t
 end
 
 
@@ -181,51 +181,50 @@ Base.show(stream, ::MIME"text/latex", x::Tableau) = write(stream, nicePrintTable
 Used by `show` to 'text' print out the Tableau based on the state.
 """
 function pformat(tab::Tableau)::String
-	# prints the Heisnberg representation of the state array supplied
-	state = tab.state
+    # prints the Heisnberg representation of the state array supplied
+    state = tab.state
 
-	toOutput::String = "\n"
-	n=div(size(state,1),2)
-	#  print("Size of system (N) is ",n,"qubits\n\n")
-	#  1 in a and a+n = Y
-  #  else 1 in a = X
-	#  else 1 in a+n=Z
-	#  otherwise I
-	# last bit is sign.
-	for row=1:n
-	  if state[row,2*n+1] == 1
-		toOutput *= "-"
-	  else
-		toOutput *= "+"
-	  end
-	  for col=1:n
-	     toOutput *= decode(state[row,col],state[row,col+n])
-	  end
-	  toOutput *= "\n"
-	end
-	for dot=1:n+1
-		toOutput *= "-"
-	end
-	toOutput *= "\n"
-	for row=n+1:2*n
-	  if state[row,2*n+1] == 1
-		  toOutput *= "-"
-	  else
-		  toOutput *= "+"
-	  end
-	  for col=1:n
-		  toOutput *= decode(state[row,col],state[row,col+n])
-	  end
-	  toOutput *= "\n"
-	end
-	return toOutput
+    toOutput::String = "\n"
+    n=div(size(state,1),2)
+    #  1 in a and a+n = Y
+    #  else 1 in a = X
+    #  else 1 in a+n=Z
+    #  otherwise I
+    #  last bit is sign. (exponent of -1).
+    for row=1:n
+      if state[row,2*n+1] == 1
+        toOutput *= "-"
+      else
+        toOutput *= "+"
+      end
+      for col=1:n
+         toOutput *= decode(state[row,col],state[row,col+n])
+      end
+      toOutput *= "\n"
+    end
+    for dot=1:n+1
+        toOutput *= "-"
+    end
+    toOutput *= "\n"
+    for row=n+1:2*n
+      if state[row,2*n+1] == 1
+          toOutput *= "-"
+      else
+          toOutput *= "+"
+      end
+      for col=1:n
+          toOutput *= decode(state[row,col],state[row,col+n])
+      end
+      toOutput *= "\n"
+    end
+    return toOutput
 end
 
 
 
 
 """
-	cnot(t::Tableau,control::Integer,target::Integer,showOutput=false)
+    cnot(t::Tableau,control::Integer,target::Integer,showOutput=false)
 
 Performs a CNOT (controlled not) on the tableau, with the specified qubits
 as control and target.
@@ -255,8 +254,8 @@ function cnot(t::Tableau,control::Integer,target::Integer,showOutput=false)
     return
   end
   if t.trackCommands
-  	append!(t.commands,["cnot($control,$target)"])
-  	append!(t.executeCommands,[Expr(:call,:cnot,:_t,control,target)])
+    append!(t.commands,["cnot($control,$target)"])
+    append!(t.executeCommands,[Expr(:call,:cnot,:_t,control,target)])
   end
   for i = 1:(2*n)
       ri=state[i,endC]
@@ -270,7 +269,7 @@ function cnot(t::Tableau,control::Integer,target::Integer,showOutput=false)
       #print("a is $(a) b is $(b), xia is $(xia) xib is $(xib), setting $([i,b]) to $(state[i,b])\n")
    end
    if showOutput
-	   print(t)
+       print(t)
    end
 end
 
@@ -290,12 +289,12 @@ function hadamard(t::Tableau,qubit::Integer,showOutput::Bool=false)
 
   if qubit < 0 || qubit > n
     print("Qubit $(qubit) out of range of state (tableau only has $(n) qubits)\n")
-	throw(BoundsError())
+    throw(BoundsError())
     return
   end
   if t.trackCommands
-  	append!(t.commands,["hadamard($qubit)"])
-  	append!(t.executeCommands,[Expr(:call,:hadamard,:_t,qubit)])
+    append!(t.commands,["hadamard($qubit)"])
+    append!(t.executeCommands,[Expr(:call,:hadamard,:_t,qubit)])
   end
   for i = 1:(2*n)
       ri=state[i,endC]
@@ -306,12 +305,12 @@ function hadamard(t::Tableau,qubit::Integer,showOutput::Bool=false)
       state[i,qubit+n]=xia
    end
    if showOutput
-	  print(t)
+      print(t)
    end
 end
 
 """
-	hadamard(t::Tableau,qubits::Integer...;showOutput::Bool = false)
+    hadamard(t::Tableau,qubits::Integer...;showOutput::Bool = false)
 
 Peforms hadamards on **each** of the qubits supplied.
 
@@ -323,12 +322,12 @@ julia> hadamard(t,2,3,1)
 See also: [`cnot`](@ref) [`phase`](@ref), [`measure`](@ref), [`X`](@ref), [`Z`](@ref)
 """
 function hadamard(t::Tableau,qubits::Integer...;showOutput::Bool = false)
-	for i in qubits
-		hadamard(t,i,false)
-	end
-	if showOutput
-	   print(t)
-	end
+    for i in qubits
+        hadamard(t,i,false)
+    end
+    if showOutput
+       print(t)
+    end
 end
 
 
@@ -350,13 +349,13 @@ function phase(t::Tableau,qubit::Integer,showOutput::Bool=false)
 
   if qubit < 0 || qubit > n
     print("Qubit $(qubit) out of range of state (tableau only has $(n) qubits)\n")
-	throw(BoundsError())
-	return
+    throw(BoundsError())
+    return
    end
   # so we need two loops!
   if t.trackCommands
-	  append!(t.commands,["phase($qubit)"])
-  	  append!(t.executeCommands,[Expr(:call,:phase,:_t,qubit)])
+      append!(t.commands,["phase($qubit)"])
+      append!(t.executeCommands,[Expr(:call,:phase,:_t,qubit)])
   end
   for i = 1:(2*n)
       ri=state[i,endC]
@@ -371,13 +370,13 @@ function phase(t::Tableau,qubit::Integer,showOutput::Bool=false)
       state[i,qubit+n]=j_xor(xia,zia)
    end
    if showOutput
-	  print(t)
+      print(t)
    end
 end
 
 
 """
-	phase(t::Tableau,qubits::Integer...;showOutput::Bool = false)
+    phase(t::Tableau,qubits::Integer...;showOutput::Bool = false)
 
 Peforms phase on each of the qubits supplied.
 
@@ -389,12 +388,12 @@ julia> phase(t,2,3,1)
 See also: [`cnot`](@ref) [`hadamard`](@ref), [`measure`](@ref), [`X`](@ref), [`Z`](@ref)
 """
 function phase(t::Tableau,qubits::Integer...;showOutput::Bool = false)
-	for i in qubits
-		phase(t,i,false)
-	end
-	if showOutput
-	   print(t)
-	end
+    for i in qubits
+        phase(t,i,false)
+    end
+    if showOutput
+       print(t)
+    end
 end
 
 
@@ -407,15 +406,15 @@ Convenience function to perform a 'Z' gate on the tableau. Performs two phase ga
 See also: [`cnot`](@ref), [`hadamard`](@ref), [`measure`](@ref), [`X`](@ref), [`phase`](@ref)
 """
 function Z(t::Tableau,qubit::Integer,showOutput::Bool=false)
-	phase(t,qubit,false)
-	phase(t,qubit,false)
-	if showOutput
- 	   print(t)
+    phase(t,qubit,false)
+    phase(t,qubit,false)
+    if showOutput
+       print(t)
     end
 end
 
 """
-	Z(t::Tableau,qubits::Integer...;showOutput::Bool = false)
+    Z(t::Tableau,qubits::Integer...;showOutput::Bool = false)
 
 Convenience function to perform a 'Z' gate on the tableau on each of the qubits supplied. Performs the gate by doing two phase gates.
 
@@ -427,12 +426,12 @@ julia> Z(t,2,3,1)
 See also: [`cnot`](@ref) [`hadamard`](@ref), [`measure`](@ref), [`X`](@ref), [`Z`](@ref)
 """
 function Z(t::Tableau,qubits::Integer...;showOutput::Bool = false)
-	for i in qubits
-		Z(t,i)
-	end
-	if showOutput
-	   print(t)
-	end
+    for i in qubits
+        Z(t,i)
+    end
+    if showOutput
+       print(t)
+    end
 end
 
 """
@@ -443,17 +442,17 @@ Convenience function to perform an 'X' gate on the tableau. Performs hadamard, t
 See also: [`cnot`](@ref), [`hadamard`](@ref), [`measure`](@ref), [`Z`](@ref), [`phase`](@ref)
 """
 function X(t::Tableau,qubit::Integer,showOutput::Bool=false)
-	hadamard(t,qubit,false)
-	phase(t,qubit,false)
-	phase(t,qubit,false)
-	hadamard(t,qubit,false)
-	if showOutput
- 	   print(t)
+    hadamard(t,qubit,false)
+    phase(t,qubit,false)
+    phase(t,qubit,false)
+    hadamard(t,qubit,false)
+    if showOutput
+       print(t)
     end
 end
 
 """
-	X(t::Tableau,qubits::Integer...;showOutput::Bool = false)
+    X(t::Tableau,qubits::Integer...;showOutput::Bool = false)
 
 Convenience function to perform an 'X' gate on the tableau on each of the qubits supplied.
 Performs the gate by doing a hadamard, two phase gates and a hadamard on each of the qubits.
@@ -466,12 +465,12 @@ julia> X(t,2,3,1)
 See also: [`cnot`](@ref) [`hadamard`](@ref), [`measure`](@ref), [`phase`](@ref), [`Z`](@ref)
 """
 function X(t::Tableau,qubits::Integer...;showOutput::Bool = false)
-	for i in qubits
-		X(t,i,false)
-	end
-	if showOutput
-	   print(t)
-	end
+    for i in qubits
+        X(t,i,false)
+    end
+    if showOutput
+       print(t)
+    end
 end
 
 
@@ -488,64 +487,54 @@ function measure(t::Tableau,qubit::Integer)
   endC=2*n+1
 
   if qubit < 0 || qubit > n
-	 print("Qubit $(qubit) out of range of state (tableau only has $(n) qubits)\n")
-  	 throw(BoundsError())
+     print("Qubit $(qubit) out of range of state (tableau only has $(n) qubits)\n")
+     throw(BoundsError())
      return
   end
   if t.trackCommands
-	  append!(t.commands,["measure($qubit)"])
-  	  append!(t.executeCommands,[Expr(:call,:measure,:_t,qubit)])
+      append!(t.commands,["measure($qubit)"])
+      append!(t.executeCommands,[Expr(:call,:measure,:_t,qubit)])
   end
-  aSlice=state[(n+1):end,:]
-  # aSlice is a "slice" of the tableau, being the stabiliser part.
-
-  if sum(aSlice[:,qubit]) > 0
-	   # we have a one on the xia somewhere.
-	   # This makes it a random measurement
-  	 p = n+argmax(aSlice[:,qubit]); # Find the first stabiliser with an X in this qubit.
-	   # print("Random first x row is ",p,"\n\n")
-     # First rowsum(state,i,p) for all i 1..2n where i!=p and xia =1
-	 # If another stabiliser/de-stabiliser has an x in this position
-	 # -> "Get rid of the X in this qubit position, by using rowsum with this stabiliser"
-   	 for h=1:2n # h is what we use in rowsum, i is p in rowsum
-	     if (h!=p) && (state[h,qubit]==1)
-		      rowsum(state,h,p)
-	     end
-	  end
-	 # Second step set p-nth to equal p, in otherwords because of the measurement the stabiliser
-	 # Has now become a destabiliser.
-	 # 1) We know that it commutes with all the other stabilisers and all the destabilisers.
-	 # 2) We know that if we create a new stabiliser with only a Z in the qubit this will anti-commute with that one.
-	 state[p-n,:]=state[p,:]
-     # Third step set pth row to be 0, except rp = 0 or 1 and zpa = 1
-	 # That is the 'stabiliser' will now be something that is consistent with the measurement.
-	 #print("Rolling metaphysical dice...\n")
-	 value = round.(Integer,rand()) # check distribution (did we roll a 1 or a 0)
-	 state[p,:]=zeros(2*n+1) # All of them zero
-	 state[p,endC]=value # Set the end approrpiately.
-	 state[p,n+qubit]=1
-    # output(state)
-	  # print("\n")
-    return value
+  if sum(state[(n+1):end,qubit]) > 0
+     # we have a one on the xia somewhere.
+     # This makes it a random measurement
+     p = n+argmax(state[(n+1):end,qubit]); # Find the first stabiliser with an X in this qubit.
+     # set p-nth to equal p, (because of the measurement the stabiliser
+     # has now become a destabiliser. I.e. it will anti-commute with the measurement, but
+     # commutes with everything else).
+     state[p-n,:]=state[p,:]
+     # Now set up the measurment 'stabiliser' this can be just IIs with a Z in the appropriate
+     # qubit (and the 'r' set to 1 or 0 depending on the random outcome)
+     value = round.(Integer,rand()) # check distribution (did we roll a 1 or a 0)
+     state[p,:]=zeros(2*n+1) # All of them zero
+     state[p,endC]=value # Set the end approrpiately.
+     state[p,n+qubit]=1 # Set the 'z' qubit 
+     # Finally we need to make everything commute with the measurment.
+     # we do this my right multiplying everything that doesn't commute with the de-stabiliser.
+     for h=1:2n # h is what we use in rowmult!
+       if (h!=p-n) && (state[h,qubit]==1) # We have an X (or Y) in the relevant qubit
+         rowmult!(state,h,p-n)
+       end
+     end
+    return value # the result of the measurement.
   else
       # print("Deterministic\n\n")
        #first set the 2n+1 row i.e. scratch space to be zero
        scratch=zeros(Int32,2n+1)' # hey 2n works dont you know
        state = vcat(state,scratch) # add it on.
-       #second call rowsum(2n+1,i+n) for all i in 1..n where xia = 1
        for i = 1:n
-	       if state[i,qubit]==1
-	         rowsum(state,2n+1,i+n)
+         if state[i,qubit]==1
+           rowmult!(state,2n+1,i+n)
          end
        end
        value = state[2n+1,endC]
        state=state[1:end-1,:]
-      # print("After\n")
-      # output(state)
-      # print("\n")
        return value
    end
 end
+
+
+
 
 """
     measure(t::Tableau,qubits::Integer...;showOutput = false)
@@ -575,43 +564,43 @@ julia>
 ```
 """
 function measure(t::Tableau,qubits::Integer...;showOutput = false)
-	outcomes = Dict()
-	for i in qubits
-		outcomes[i] = measure(t,i)
-	end
-	print(outcomes)
-	if showOutput
-	   print(t)
-	end
+    outcomes = Dict()
+    for i in qubits
+        outcomes[i] = measure(t,i)
+    end
+    print(outcomes)
+    if showOutput
+       print(t)
+    end
 end
 
 
 """
-	kets(tableau::Tableau)
+    kets(tableau::Tableau)
 
 returns a string showing the kets of the state stabilised by the tableau.
 """
 function kets(originalTableau::Tableau)
 
-	#Use gaussian Elimination to provide a minimal set of generators
-	# containing X's and Y's in upper triangular form
-	ss1 = gaussianElimination(originalTableau.state)
+    #Use gaussian Elimination to provide a minimal set of generators
+    # containing X's and Y's in upper triangular form
+    ss1 = gaussianElimination(originalTableau.state)
 
-	state=ss1[1]
+    state=ss1[1]
     n=ss1[2]
 
-	start=seed(state,n)
+    start=seed(state,n)
     scratchState=copy(start) # the first nqubits are the destabilisers
     outputString = printBasisState(vec(scratchState))
 
-	# So the idea is we have the stabilisers with an X in them in upper triangular form
+    # So the idea is we have the stabilisers with an X in them in upper triangular form
     # Each X represents a "1" in the Ket
     # But we need to generate each of the states stabilised by these Paulis.
     # For the first row, the ones generated are where there is an X in the first row.
     # On the second row, the ones generated are the second row, and the second row multiplied by the first.
     # On the third row, its the third row, third times first, third times second and third times first and second
     # etc.
-    # Aaronsen has a really neat algorighm to do this, but its not easily understood.
+    # Aaronsen has a really neat algorithm to do this, but its not easily understood.
     # I have used this, slighly less efficient, but (I hope) more comprehenisible algorithm
     # For a particular row (say we are looking at our third row with an X in it (n 3)
     # loop through the numbers 4:7 (being 2^(3-1) to (2^3)-1)
@@ -620,18 +609,13 @@ function kets(originalTableau::Tableau)
     # Then we need to multiply the rows together if 2^(row-1) (i.e. row 2 - equates to bit 2) is not zero when
     # logically anded with the count.
 
-	number=2^(n-1)
+    number=2^(n-1)
     nqubits=div(size(state,1),2)
-    #println("nqubits is $nqubits")
     for count = 0:(2^(n-1)-2)
         c2=xor(count,(count+1))
-        #println("count is now $count c2 is $c2\n")
         for rows=0:(n-2)
-            #println("count: $count, c2 is $c2, rows is now $rows\n")
             if (2^(rows) & c2) > 0
-               #println("******Row mult \nscratchState is $scratchState\n State: $(state[nqubits+rows+1,:])\n")
                scratchState=rowmult(scratchState,state[nqubits+rows+1,:])
-               #println("\n**scratchState is now $scratchState\n\n")
             end
         end
         # Note the use of vec here, just makes sure that the scratch state is a vectdor
@@ -654,63 +638,63 @@ function nicePrintTableauState(t::Tableau)
   n = t.qubits
   toOuptut = ""
   if !t.showRaw
-	  start = string("\\begin{equation*} \\left(\\begin{array}{l|c*{$n}c}")
-	  for row=1:n
-		  if state[row,2*n+1] == 1
-			toOutput = "-&"
-		  else
-			toOutput = "+&"
-		  end
-	      start = "$start $toOutput &"
-		  for col=1:n
-		     start = "$start $(decode(state[row,col],state[row,col+n])) "
+      start = string("\\begin{equation*} \\left(\\begin{array}{l|c*{$n}c}")
+      for row=1:n
+          if state[row,2*n+1] == 1
+            toOutput = "-&"
+          else
+            toOutput = "+&"
+          end
+          start = "$start $toOutput &"
+          for col=1:n
+             start = "$start $(decode(state[row,col],state[row,col+n])) "
          if (col != n)
             start = "$start & "
           end
-		  end
-		  start = "$start \\\\\n"
-		end
-		start = "$start \\hline\n"
-		for row=n+1:2*n
-		  if state[row,2*n+1] == 1
-			toOutput = "-&"
-		  else
-			toOutput = "+&"
-		  end
-	      start = "$start $toOutput &"
-		  for col=1:n
- 	        start = "$start $(decode(state[row,col],state[row,col+n])) "
+          end
+          start = "$start \\\\\n"
+        end
+        start = "$start \\hline\n"
+        for row=n+1:2*n
+          if state[row,2*n+1] == 1
+            toOutput = "-&"
+          else
+            toOutput = "+&"
+          end
+          start = "$start $toOutput &"
+          for col=1:n
+            start = "$start $(decode(state[row,col],state[row,col+n])) "
             if (col != n)
               start = "$start & "
             end
 
-		  end
-		  start = "$start \\\\\n"
-		end
-	    start = "$start \\end{array}\\right)\\\\\\end{equation*}"
-	  return start
-	else
-		start = string("\\begin{equation*} \\begin{array}{l$(join(["c" for i =1:n]))|$(join(["c" for i =1:n]))|c}")
-		toshift = round(Integer,n/2,RoundUp)
-		start = "$start\n$(join(["&" for i =1:toshift]))\\textbf{X}$(join(["&" for i =1:(n-toshift)]))$(join(["&" for i =1:toshift]))\\textbf{Z}$(join(["&" for i =1:(n-toshift)]))\\\\\n"
-		for row=1:n
-		  start = "$start D$(row): &"
-  		  for col=1:(2n)
-  		     start = "$start $(state[row,col]) &"
-  		  end
-  		  start = "$start $(state[row,2n+1]) \\\\\n"
-  		end
-  		start = "$start \\hline\n"
-  		for row=n+1:2*n
-			start = "$start S$(row-n): &"
-    		 for col=1:(2n)
-  		     start = "$start $(state[row,col]) &"
-  		  end
-  		  start = "$start $(state[row,2n+1])\\\\\n"
-  		end
-  	    start = "$start \\end{array}\\\\\\end{equation*}"
-  	  	return start
-	end
+          end
+          start = "$start \\\\\n"
+        end
+        start = "$start \\end{array}\\right)\\\\\\end{equation*}"
+      return start
+    else
+        start = string("\\begin{equation*} \\begin{array}{l$(join(["c" for i =1:n]))|$(join(["c" for i =1:n]))|c}")
+        toshift = round(Integer,n/2,RoundUp)
+        start = "$start\n$(join(["&" for i =1:toshift]))\\textbf{X}$(join(["&" for i =1:(n-toshift)]))$(join(["&" for i =1:toshift]))\\textbf{Z}$(join(["&" for i =1:(n-toshift)]))\\\\\n"
+        for row=1:n
+          start = "$start D$(row): &"
+          for col=1:(2n)
+             start = "$start $(state[row,col]) &"
+          end
+          start = "$start $(state[row,2n+1]) \\\\\n"
+        end
+        start = "$start \\hline\n"
+        for row=n+1:2*n
+            start = "$start S$(row-n): &"
+             for col=1:(2n)
+             start = "$start $(state[row,col]) &"
+          end
+          start = "$start $(state[row,2n+1])\\\\\n"
+        end
+        start = "$start \\end{array}\\\\\\end{equation*}"
+        return start
+    end
 end
 
 # ============== Internal Functions ==========================
@@ -744,92 +728,12 @@ function setup(n)
   state = vcat(top,bottom)
 end
 
-
-
-"""
- GottesmanG(x1,z1,x2,z2)
-
- Input:
-    x1z1 and x2z2 represent pauli matrices by the usual 'tableau' manner
-    e.g. both are 1 = Y gate, both 0 = I, otherwise same as the one thats 1.
-
- Returns:
-    this returns the exponent to which i is raised if we multiply x1z1 by x2z2
-
- Note:
-    I can't remember why we need this as opposed to just using cliffordPhase.
-"""
-function GottesmanG(x1,z1,x2,z2)
-
-  if x1==0
-    if z1 == 0 # x1=0 z1=0, so multiplying by I
-       return 0
-    else  # x1=0 z1=1, so multiplying by Z
-       return x2*(1-2*z2) 
-       # This confused me when I came back to it
-       # Remember ZX=iY and ZY=-iX, so 1 and -1
-    end
-  else
-    if z1 == 0 # x1=1, z1=0, so multiplying by X
-       return z2*(2*x2-1)
-       # Again, relevantly XZ=-iY (-1), XY=iZ (1)
-    else # x1=1 z1=1
-       return z2-x2 #YZ=iX (1), YX=-iZ (-1)
-    end
-  end
-end
-
-"""
-function rowsum(state,h,i)
-    - 'sums' two rows in the state matrix.
-    - Pass in integers to the rows, not the rows themselves
-"""
-function rowsum(state,h,i)
-  # This is another example of Aaronson's paper flitting between r's being stored as 1 or 0
-  # And his implementation where he stores them as the power to take i to. (I think there is another example of 
-  # this in the stuff related to geting the Output states.)
-  # It's related to the fact that the GottesmanG function returns the power i is raised to.
-  # The worry here is a little redundant, but I will take r and multiply by 2, as this then becomes the power 
-  # i is raised to, i.e. we are in the same "units" as the return of the GottemanG function.
-  # - If you follow the code through though you will see it is redundant as I am just modding by 4 adnd then
-  # checking if its ==2, which would be the same as modding by 2 and checking if ==1
-  # @TODO unit test so I can change it back and be confident it still works!
-
-  # "sums" two rows in the state matrix
-  # pass in integers to the rows, not the rows themselves.
-  n=div(size(state,1),2)
-  total = 0;
-  # Step through the qubits in the row to determine overall phase.
-  # - @TODO work out if this is different from cliffordPhase(i,k)
-  for j=1:n
-	  xij=state[i,j]
-      zij=state[i,n+j]
-      xhj=state[h,j]
-	  zhj=state[h,n+j]
-	  total += GottesmanG(xij,zij,xhj,zhj)
-  end
-  rh= state[h,2*n+1]
-  ri= state[i,2*n+1]
-  grandTotal=2*rh+2*ri+2*total #TODO why am I multiplying total by 2.
-  if mod(grandTotal,4) == 0
-	state[h,2*n+1]=0
-  elseif mod(grandTotal,4) == 2
-	state[h,2*n+1]=1
-  else
-	   print("Failed sanity check the grandTotal ",grandTotal, " which mods to ",mod(grandTotal,4),"\n")
-  	 return
-  end
-  # Now that we know the phase we can 'sum' the stabilisers.
-  for j=1:n
-	state[h,j]=j_xor(state[i,j],state[h,j]) # xhj=xij j_xor xhj
-	state[h,n+j]=j_xor(state[i,n+j],state[h,n+j])
-  end
-end
-
 # This is just mod 2 arithmetic.
 function j_xor(a,b)
   return mod.(a+b,2)
 end
+
+
 
 
 function rowswap!(alteredState,i,k)
@@ -838,118 +742,102 @@ function rowswap!(alteredState,i,k)
       alteredState[k,:]=temp
 end
 
+""" 
+    cliffordPhase(i,k)
+
+    Pass in two vectors representing rows in a Tableau.
+
+    Returns the exponent i is raised to (0,1,2 or 3) if i is left multiplied by k.
+    ---
+    Note: Assumes that the 'r' part of i (in position 2n+1) has ALREADY been changed from
+    an exponent of -1 (which is how it is in the Tableau) to an exponent of i
+    (by multiplying it by 2). It also assumes k is still in the range of 0..1 i.e. an
+    exponent of -1
+"""
 function cliffordPhase(i,k)
   # Returns the phase (0,1,2,3) when row i is left multiplied by row k
   # println("CliffordPhase $i,$k")
   e=0
   n=div(length(i),2)
-  #println("n is $n")
   for j=1:n
     if k[j] == 1 && k[j+n]==0 # its an X
       if i[j] == 1 && i[j+n] == 1 # its a Y
-        #print("XY\n")
         e+=1 # XY=iZ
       elseif   i[j] == 0 && i[j+n] == 1 # its a Z
-        #print("XZ\n")
-        e+=-1 # XY=-iZ
+        e+=-1 # XZ=-iY
       end
     elseif  k[j] == 1 && k[j+n]==1 # its a Y
       if i[j] == 0 && i[j+n] == 1       # its a Z
-        #print("YZ\n")
         e+=1 # YZ=iXZ
       elseif i[j] == 1 && i[j+n] == 0 # its a X
-        #print("YX\n")
         e+=-1 # YX=-iZ
       end
     elseif  k[j] == 0 && k[j+n]==1 # its a Z
       if i[j] == 1 && i[j+n] == 0       # its a X
-        #print("ZX\n")
         e+=1 # ZX=iY
       elseif i[j] == 1 && i[j+n] == 1 # its a Y
-        #print("ZY\n")
         e+=-1 # ZY=-iX
       end
     end
   end
 
- # NOTE the 2* in front of k but not i
- # This is a TERRIBLE hack
- # See rowmult! for the full grimy disclosure.
   e = e + i[2*n+1] + 2*k[2*n+1]
-   #print("E is now $e\n")
   e = e%4
   if (e < 0)
     e+=4
   end
-   #print("modded E is now $e\n")
-
+  
   return e
 end
 
+"""
+    rowmult!(stateArray,i,k)
 
-# This one is called by measure
-function rowmult!(alteredState,i,k) # does the multiplication in place in a state array.
-  # left multiply row i by row k
-  # println("Rowmult! with $i and $k")
-  n=div(size(alteredState,1),2)
+    stateArray - the state of a Tableau
+    i the (integer) row of the stateArray that will hold the result of i left multiplied by 
+      row pointed to by k.
+    k the (integer) row with which i is to be left multiplied.
 
+    Note: assumes that both 'r' components of the Tableau rows are exponents of -1
+    use _rowmult! if i has already been lifted up to be an exponent of i.
+""" 
+function rowmult!(stateArray,i,k)
+    n=div(size(stateArray,1),2)
+    # Note cliffordPhase assumes the first row has the 'r' component changed to represent
+    # a phase of i, we do this here by multiplying it by 2
+    # and then after the row multiplication dividing it by 2.
+    stateArray[i,2n+1] *=2
+    _rowmult!(stateArray,i,k)
+    stateArray[i,2n+1] = div(stateArray[i,2n+1],2)
+    
+end
 
-  # This is part of a TERRIBLE hack.
-  # For the purpose of the *tableau* we only need to record an r which is 0 or 1 (in place 2*n+1)
-  # And so rather than allow it four values, the software was coded using a 0 or 1
-  # This makes matching the stuff on page 4 column 2 to the code (imo) easier, it directly matches the maths.
-  # HOWEVER, when printing out the basis (getStatesFor) we need all four possible states +1,i,-1,-i
-  # So we can't just divide the Clifford phase by 2.
-  # All the syplectic stuff built on top of this assumes r = 0 or 1, so I don't want to revert to the Aaronson code
-  # which has r ranging from 0->3 (and divides by 2 normally)
-  # But afaik this only impact when we getStatesFor (to print out the basis states).
-
-  # So.. (the HACK) ... when you call cliffordPhase it assumes the first row has an r that has been multiplied by 2
-  # i.e. can be between 0..3, but the second will be either 0 or 1. That is how rowmult works (basically it has a different
-  # scratch state and we 'reinterpret' the r so it can 0..3, and printBasisState deals with this.)
-  # BUT here we are only interested in 0 or 1, but we have to multiply the r for the first state passed into cliffordPhase by 2
-  # (i.e. convert to the 0..3 scale) and then divide the result by 2, to get from the 0..3 scale to the 0,1 scale.
-  # as I said (terrible hack).
-
-
-  # Multiply this one by two (0..3) scale
-  alteredState[i,2*n+1] = alteredState[i,2*n+1]*2
- #   println("alteredState : $(alteredState[i,:])")
- #   println("secondState : $(alteredState[k,:])")
-
-  phaseBack = cliffordPhase(alteredState[i,:],alteredState[k,:])
- #    println("Clifford phase returned $(phaseBack)")
-  if (phaseBack  == 1 || phaseBack  ==3)
-    println("phaseBack  WAS 1 OR 3")
-  end
-  # Divide answer by 2 (from 0..3->0..1 scale.)
-  # alteredState[i,2*n+1] = alteredState[i,2*n+1]/2
-#  println("Changed to $(phaseBack/2)")
-
- #println("Setting altered state to $(alteredState[i,2*n+1])")
-  #println("back")
-  alteredState[i,:] = xor.(alteredState[i,:],alteredState[k,:])
-  # we dont xor the r bits.
-  alteredState[i,2*n+1] = phaseBack/2
-# println("Returning an alterestate of $(alteredState[i,:])")
+function _rowmult!(stateArray,i,k)
+    n=div(size(stateArray,1),2)
+    # print(stateArray[i,:],stateArray[k,:])
+    phaseBack = cliffordPhase(stateArray[i,:],stateArray[k,:])
+    if (phaseBack  == 1 || phaseBack  ==3)
+        println("phaseBack $phaseBack WAS 1 OR 3")
+    end
+    stateArray[i,:] = xor.(stateArray[i,:],stateArray[k,:])
+    stateArray[i,2*n+1] = phaseBack
 end
 
 
-# This one is called by getStatesFor (which prints out the relevant basis states).
+
+"""
+    rowmult(i,k)
+    
+    i,k two vectors, equivalent to rwos in a Tableau.
+    Left multiplies i with k and returns the result.
+    Note it assumes that the 'r' in i is an exponent of i
+    Whereas the 'r' in k is an exponent of -1.
+"""
 function rowmult(i,k) # supply two vectors and get the multiplied vector out.
-  #println("Rowmult with $i and $k")
   n=div(length(i),2)
-  #println("i is $i\nk is $k\n n is $n\n")
   temp = cliffordPhase(i,k)
-  #if (temp == 1 || temp ==3)
-  #  println("TEMP WAS 1 OR 3")
-  #end
-  #println("$i and $k and $(xor.(i,k))")
   tempState = [xor(i[c],k[c]) for c =1:length(i)] 
   tempState[length(i)]=temp
-  #println("Returning a temp of $temp\n")
-  # println("tempstate is $tempState")
-  #  tempState[2*n+1,:]=temp/2
   return tempState
  end
 
@@ -1090,15 +978,15 @@ end
 
 
 function decode(z,x)
-	if z==1
-		if x == 1
-			return "Y"
-		else
-			return "X"
-		end
-	elseif x == 1
-		return "Z"
-	else
-		return "I"
-	end
+    if z==1
+        if x == 1
+            return "Y"
+        else
+            return "X"
+        end
+    elseif x == 1
+        return "Z"
+    else
+        return "I"
+    end
 end

--- a/test/CHPTests.jl
+++ b/test/CHPTests.jl
@@ -180,3 +180,102 @@
 
 
 			end;
+
+
+	@testset "Ket tests" begin
+	# These tests are a bit 'output specific' but 
+		t = Tableau(3)
+		phase(t,1)
+		hadamard(t,1)
+		phase(t,1)
+		cnot(t,1,2)
+		cnot(t,2,3)
+		hadamard(t,3)
+		phase(t,3)
+		@test kets(t) == "+|000> \n+i|110> \n+i|001> \n+|111> \n"
+		t = Tableau(3)
+		phase(t,1)
+		hadamard(t,1)
+		phase(t,1)
+		cnot(t,1,2)
+		cnot(t,2,3)
+		hadamard(t,3)
+		phase(t,3)
+		hadamard(t,2)
+		phase(t,2)
+		phase(t,2)
+		hadamard(t,2)
+		phase(t,1)
+		phase(t,2)
+		cnot(t,2,3)
+		cnot(t,1,2)
+		@test kets(t) == "+|010> \n-i|111> \n-i|011> \n+|110> \n"
+		t = cliffordToTableau(3,34681,400)
+		@test kets(t) == "+|010> \n-i|101> \n-i|001> \n+|110> \n"
+	end
+
+	@testset "Measure tests" begin
+		for i in 1:5
+			t = Tableau(3)
+			phase(t,1)
+			hadamard(t,1)
+			phase(t,1)
+			cnot(t,1,2)
+			cnot(t,2,3)
+			hadamard(t,3)
+			phase(t,3)
+			x = measure(t,2)
+			if x == 0
+				@test kets(t) == "+|000> \n+i|001> \n"
+			else
+				@test kets(t) == "+|110> \n-i|111> \n"
+			end
+		end
+		for i in 1:5
+			t = cliffordToTableau(3,34681,400)
+			x = measure(t,1)
+			if x == 1
+				@test kets(t) == "+|110> \n-i|101> \n"
+			else
+				@test kets(t) == "+|010> \n-i|001> \n"
+			end
+		end
+		for i in 1:10
+			t = cliffordToTableau(4,434681,400)
+			z_m = Int32[1 0 1 1 0 0 1 1 1; 0 0 1 0 0 1 0 1 1; 1 1 0 0 1 1 1 0 0; 0 0 1 0 1 0 0 0 0; 0 0 0 0 0 0 0 1 0; 0 1 1 0 0 0 0 1 1; 1 1 1 0 1 1 1 1 0; 1 0 0 0 1 0 0 1 1]
+			o_m = Int32[1 0 1 1 0 0 1 1 1; 0 0 1 0 0 1 0 1 1; 1 1 0 0 1 1 1 0 0; 0 0 1 0 1 0 0 0 0; 0 0 0 0 0 0 0 1 1; 0 1 1 0 0 0 0 1 1; 1 1 1 0 1 1 1 1 0; 1 0 0 0 1 0 0 1 1]
+			x = measure(t,4)
+			if x == 0 
+				@test t.state == z_m
+			else
+				@test t.state == o_m
+			y = measure(t,3)
+			if x==1 && y == 0
+				@test kets(t) == "+|0001> \n+i|1001> \n"
+			elseif x==0 && y == 0
+				@test kets(t) == "+|0100> \n-i|1100> \n"
+			elseif x==0 && y == 1
+				@test kets(t) == "+|0010> \n-i|1010> \n"
+			else
+				@test kets(t) == "+|0111> \n+i|1111> \n"
+			end
+		end
+		for i in 1:5
+			t = cliffordToTableau(3,401,4)
+			x = measure(t,1)
+			@test x == 0
+			@test kets(t) == "+|000> \n+i|010> \n+i|001> \n-|011> \n"
+		end
+		for i in 1:5
+			t = cliffordToTableau(3,401,4)
+			hadamard(t,1)
+			phase(t,1)
+			phase(t,1)
+			hadamard(t,1)
+			x = measure(t,1)
+			@test x == 1
+			@test kets(t) == "+|100> \n+i|110> \n+i|101> \n-|111> \n"
+		end
+	end
+end
+	


### PR DESCRIPTION
functions rowmult! and rowsum did roughly the same thing, called by kets and measure respectively. 

Here they are consolidated to rowmult! (and the rowmult variant), better commented and made consistent. Various unit tests have been added to ensure that future tweaks continue to work.

The tests require very specific output from e.g. ket and this can be improved.